### PR TITLE
Add category to library.properties

### DIFF
--- a/fsm/library.properties
+++ b/fsm/library.properties
@@ -4,6 +4,7 @@ author=Jeroen Doggen
 maintainer=Jeroen Doggen <jeroendoggen@gmail.com>
 sentence=Arduino library for finite state machines
 paragraph=This a library helps when designing FSM-based Arduino projects.
+category=Other
 url=https://github.com/jeroendoggen/Arduino-finite-state-machine-library
 architectures=*
  


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Arduino-finite-state-machine-library is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
